### PR TITLE
rescue accept errors and exit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
 
 Style/FrozenStringLiteralComment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.4
-  - 2.4.1
-  - jruby-9.1.13.0
-  - ruby-head
+  - 2.5.7
+  - 2.6.5
+  - jruby-9.2.8.0
 matrix:
-  allow_failures:
-    - rvm: ruby-head
   fast_finish: true
 sudo: false

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,8 @@ require "rubocop/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
 
+# enable ObjectSpace in jruby
+ENV["JRUBY_OPTS"] ||= ""
+ENV["JRUBY_OPTS"] += " --debug -X+O"
+
 task default: %i[spec rubocop]

--- a/debug_socket.gemspec
+++ b/debug_socket.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.summary       = "Debug Socket for running ruby processes"
   spec.homepage      = "https://github.com/square/debug_socket"
 
+  spec.required_ruby_version = ">= 2.5"
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "pry"
+require "logger"
+
 require "debug_socket"


### PR DESCRIPTION
If accept has an error, it will probably never recover; don't spam logs
in a loop. Also, move the socket file cleanup into the thread rather
than requiring manual calls to `DebugSocket.stop`.