### PR TITLE
Delete socket before calling UNIXServer.new

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-### 0.1.7 20202-01-09
+### Unreleased
+- [#14](https://github.com/square/debug_socket/pull/14)
+  Delete socket if it already exists to account for orphaned sockets.
+
+### 0.1.7 2020-01-09
 
 - [#11](https://github.com/square/debug_socket/pull/11)
   Properly escape command when sent to socket.

--- a/lib/debug_socket.rb
+++ b/lib/debug_socket.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "debug_socket/version"
+require "fileutils"
 require "socket"
 require "time"
 
@@ -29,6 +30,10 @@ module DebugSocket
     old_mask = File.umask(0o0177)
 
     @path = path.to_s
+
+    # Sometimes orphaned sockets are left, so we need to remove them to avoid
+    # Errno::EADDRINUSE errors when calling UNIXServer.new
+    FileUtils.rm_f(@path)
 
     server = UNIXServer.new(@path)
     @thread = Thread.new do

--- a/spec/debug_socket_spec.rb
+++ b/spec/debug_socket_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe DebugSocket do
         .to raise_exception("debug socket thread already running for this process")
     end
 
+    context "when the socket already exists" do
+      before do
+        DebugSocket.stop
+        UNIXServer.new(path).close
+      end
+
+      it "still starts successfully" do
+        DebugSocket.start(path)
+        socket.write("1 + 2")
+        socket.close_write
+        expect(socket.read).to eq("3\n")
+      end
+    end
+
     if Process.respond_to?(:fork)
       it "can only be started once per process, including in forked children" do
         another_path = "another-boom.sock"


### PR DESCRIPTION
This accounts for cases where a previous process didn't exit cleanly and
the socket is still on the file system, so creating a new debug socket
where the path is the same will fail.