### PR TITLE
Remove socat in debug-socket script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-### 0.1.7 20202-01-09
+### Unreleased
+
+- Remove socat dependency in debug-socket script.
+
+### 0.1.7 2020-01-09
 
 - [#11](https://github.com/square/debug_socket/pull/11)
   Properly escape command when sent to socket.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-### Unreleased
+### 0.1.8 2022-10-10
 
-- Remove socat dependency in debug-socket script.
+- [#15](https://github.com/square/debug_socket/pull/15)
+  Remove socat dependency in debug-socket script.
 
 ### 0.1.7 2020-01-09
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ spec/debug_socket_spec.rb:48:in `sleep'
 spec/debug_socket_spec.rb:48:in `block (4 levels) in <top (required)>'
 ```
 
-The gem also provides a helper script that wraps the above command.  The
-`debug-socket` script takes one argument, the path to the unix socket, and it
-will run the `backtrace` command through that socket.
+The gem also provides a script.  The `debug-socket` script takes one argument,
+the path to the unix socket, and it will run the `backtrace` command through
+that socket.
 
 ```
 % debug-socket ~/tmp/puma-debug-1234.sock

--- a/exe/debug-socket
+++ b/exe/debug-socket
@@ -2,16 +2,21 @@
 # frozen_string_literal: true
 
 require "shellwords"
+require "socket"
 
 if ARGV[0].nil? || ARGV[0].empty? || ARGV[0] == "-h" || ARGV[0] == "--help"
   puts "\nUsage: debug-socket <socket-path> [<command>=backtrace]"
   exit 1
 end
 
-socket = ARGV[0]
+socket_path = ARGV[0]
 command = ARGV[1] || "backtrace"
 
-warn "\nSending `#{command}` to the following socket: #{socket}"\
+warn "\nSending `#{command}` to the following socket: #{socket_path}"\
   "----------------------------------------------------------\n\n"
 
-Kernel.exec("echo #{Shellwords.escape(command)} | socat - UNIX-CONNECT:#{socket}")
+UNIXSocket.open(socket_path) do |socket|
+  socket.write(command)
+  socket.close_write
+  puts socket.read
+end

--- a/lib/debug_socket/version.rb
+++ b/lib/debug_socket/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DebugSocket
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
This allows the script to be run in environments that don't have socat installed.