### PR TITLE
Add Auditing Callback to Debug Socket

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 0.2.0 2025-04-03
+
+- [#16](https://github.com/square/debug_socket/pull/16)
+  Allow external auditing of debug sessions.
+  (dogor@)
+
 ### 0.1.8 2022-10-10
 
 - [#15](https://github.com/square/debug_socket/pull/15)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 0.2.0 2025-04-03
+### 0.1.9 2025-04-03
 
 - [#16](https://github.com/square/debug_socket/pull/16)
   Allow external auditing of debug sessions.

--- a/lib/debug_socket.rb
+++ b/lib/debug_socket.rb
@@ -77,7 +77,7 @@ module DebugSocket
   end
 
   # Allow debug socket input commands to be audited by an external callback
-  private_class_method def self.perform_audit(input, &block)
+  private_class_method def self.perform_audit(input)
     yield @path, input
   rescue Exception => e
     logger&.error "debug-socket-error=callback unsuccessful: #{e.inspect} for #{input.inspect} socket_path=#{@path}"

--- a/lib/debug_socket.rb
+++ b/lib/debug_socket.rb
@@ -78,7 +78,7 @@ module DebugSocket
 
   # Allow debug socket input commands to be audited by an external callback
   private_class_method def self.perform_audit(input)
-    yield @path, input
+    yield input
   rescue Exception => e
     logger&.error "debug-socket-error=callback unsuccessful: #{e.inspect} for #{input.inspect} socket_path=#{@path}"
   end

--- a/lib/debug_socket.rb
+++ b/lib/debug_socket.rb
@@ -38,12 +38,12 @@ module DebugSocket
           input = socket.read
           logger&.warn("debug-socket-command=#{input.inspect}")
 
-          self.perform_audit(input, &block) if block_given?
+          self.perform_audit(input, &block) if block
 
           socket.puts(eval(input)) # rubocop:disable Security/Eval
 
         rescue Exception => e # rubocop:disable Lint/RescueException
-          logger&.error { "debug-socket-error=#{e.inspect} backtrace=#{e.backtrace.inspect} socket_path=#{path}" }
+          logger&.error { "debug-socket-error=#{e.inspect} backtrace=#{e.backtrace.inspect}" }
         ensure
           socket&.close
         end
@@ -78,10 +78,8 @@ module DebugSocket
 
   # Allow debug socket input commands to be audited by an external callback
   private_class_method def self.perform_audit(input, &block)
-    if block_given?
-      yield @path, input
-    end
+    yield @path, input
   rescue Exception => e
-    logger&.warn "debug-socket-warn=callback unsuccessful: #{e.inspect} for #{input.inspect}"
+    logger&.error "debug-socket-error=callback unsuccessful: #{e.inspect} for #{input.inspect} socket_path=#{@path}"
   end
 end

--- a/lib/debug_socket/version.rb
+++ b/lib/debug_socket/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DebugSocket
-  VERSION = "0.2.0"
+  VERSION = "0.1.9"
 end

--- a/lib/debug_socket/version.rb
+++ b/lib/debug_socket/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DebugSocket
-  VERSION = "0.1.8"
+  VERSION = "0.2.0"
 end

--- a/spec/debug_socket_spec.rb
+++ b/spec/debug_socket_spec.rb
@@ -92,14 +92,14 @@ RSpec.describe DebugSocket do
 
       it "calls the audit proc with the input" do
         audit_calls = []
-        audit_proc = proc { |path, input| audit_calls << [path, input] }
+        audit_proc = proc { |input| audit_calls << input }
 
         DebugSocket.start(path, &audit_proc)
 
         socket.write("2 + 2")
         socket.close_write
         expect(socket.read).to eq("4\n")
-        expect(audit_calls).to eq([[path, "2 + 2"]])
+        expect(audit_calls).to eq(["2 + 2"])
       end
 
       it "does not raise if the audit proc raises, and still processes the command" do
@@ -111,7 +111,7 @@ RSpec.describe DebugSocket do
         socket.close_write
         expect(socket.read).to eq("6\n")
         # No error should be raised to the client, and the command is processed
-        expect(log_buffer.string).to include('debug-socket-error=callback unsuccessful: #<RuntimeError: audit error> for "3 + 3" socket_path=' + path)
+        expect(log_buffer.string).to include('debug-socket-error=callback unsuccessful: #<RuntimeError: audit error> for "3 + 3"')
       end
     end
   end

--- a/spec/debug_socket_spec.rb
+++ b/spec/debug_socket_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe DebugSocket do
         socket.close_write
         expect(socket.read).to eq("6\n")
         # No error should be raised to the client, and the command is processed
-        expect(log_buffer.string).to include('debug-socket-warn=callback unsuccessful: #<RuntimeError: audit error> for "3 + 3"')
+        expect(log_buffer.string).to include('debug-socket-error=callback unsuccessful: #<RuntimeError: audit error> for "3 + 3" socket_path=' + path)
       end
     end
   end


### PR DESCRIPTION
**Summary:**
Allow the socket to send commands received to an audit method for usage outside the library.